### PR TITLE
FIX Load migration statuses before rollback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - "1.8"
   - "1.10.x"
   - master
 services:

--- a/gomigrate.go
+++ b/gomigrate.go
@@ -184,6 +184,7 @@ func (m *Migrator) Migrations(status int) []*Migration {
 			migrations = append(migrations, migration)
 		}
 	}
+
 	return migrations
 }
 
@@ -274,6 +275,11 @@ func (m *Migrator) Rollback() error {
 
 // RollbackN rolls back N migrations.
 func (m *Migrator) RollbackN(n int) error {
+	// checks the database for migration statuses
+	if err := m.getMigrationStatuses(); err != nil {
+		return err
+	}
+
 	migrations := m.Migrations(Active)
 	if len(migrations) == 0 {
 		return nil

--- a/gomigrate_test.go
+++ b/gomigrate_test.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"testing"
 
+	_ "github.com/denisenkom/go-mssqldb"
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
-	_ "github.com/denisenkom/go-mssqldb"
 )
 
 var (


### PR DESCRIPTION
Load migration statuses before `Rollback()`, otherwise it can never run on a new instance of migrator - all migrations are by default marked as `inactive`, while rollback runs only for those marked `active`.

Tests did pass because migrations already have correct statuses since `Migrate()` ran first on the same instance of migrator. This caused both initial status check and updated it when applying the migration.

**IMPORTANT:** supported go versions >=1.10